### PR TITLE
Allow-dash-resource-names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 sudo: false
 python:
-- '2.7'
-- '3.6'
 - '3.7'
+- '3.8'
+- '3.9'
 install:
 - pip install --upgrade tox-travis -r requirements-build.txt -r requirements-test.txt
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v0.2.0 (2022-03-09)
+
+  * Add method to be able to support resource names with "-" in the name
+  * Support Login based on usernames or email keys
+  * Drop support for Python 2. Test on v3.8 and v3.9
+
 ### v0.1.2 (2020-06-01)
 
   * Remove dependency on unitest2

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Package is based on https://github.com/samgiles/slumber, but enhanced to support
 
 restframeworkclient requires the following modules.
 
-    * Python 2.7+ or 3.4+
+    * Python 3.7+
     * requests
 
 ## Installation
 
-```
+```bash
+python3 -m venv .virtualenv/drf_client
+source .virtualenv/drf_client/bin/activate
 pip install django-rest-framework-client
 ```
 
@@ -42,13 +44,14 @@ options = {
     'API_PREFIX': 'api/v1',
     'TOKEN_TYPE': 'jwt',
     'TOKEN_FORMAT': 'JWT {token}',
+    'USERNAME_KEY': 'username',
     'LOGIN': 'auth/login/',
     'LOGOUT': 'auth/logout/',
 }
 
 c = RestApi(options)
 
-ok = c.login(email=email, password=password)
+ok = c.login(username=username, password=password)
 if ok:
 
     # GET some data
@@ -99,13 +102,18 @@ urlpatterns = [
 
 To test, run python setup.py test or to run coverage analysis:
 
-```
+```bash
+python3 -m venv .virtualenv/drf_client
+source .virtualenv/drf_client/bin/activate
+pip install -r requirements-test.txt
+pip install -e .
+
 coverage run --source=iotile_cloud setup.py test
 coverage report -m
 ```
 
 You can also use py.test:
 
-```
+```bash
 py.test
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ if ok:
 
     resp = c.myresourcename.post(data=payload)
 
+    # If the URL includes "-", add under parenthesis:
+    # GET: /api/v1/someresource/some-path/
+    my_object = c.someresource('some-path').get()
+
 ```
 
 

--- a/drf_client/connection.py
+++ b/drf_client/connection.py
@@ -229,9 +229,13 @@ class Api(object):
     def set_token(self, token):
         self.token = token
 
-    def login(self, password, email):
+    def login(self, password, username=None):
         assert('LOGIN' in self.options)
-        data = {'email': email, 'password': password}
+        # This allows us to suport both a {'email': username} and {'username": username}
+        # Default to 'username' which is the default DRF behavior
+        username_key = self.options.get('USERNAME_KEY', 'username')
+        data = {'password': password}
+        data[username_key] = username 
         url = '{0}/{1}'.format(self.base_url, self.options['LOGIN'])
 
         payload = json.dumps(data)

--- a/example.py
+++ b/example.py
@@ -8,7 +8,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 logger = logging.getLogger(__name__)
 
-email = input('Email? ')
+username = input('Email? ')
 password = getpass.getpass()
 
 options = {
@@ -16,13 +16,14 @@ options = {
     'API_PREFIX': 'api/v1',
     'TOKEN_TYPE': 'jwt',
     'TOKEN_FORMAT': 'JWT {token}',
+    'USERNAME_KEY': 'username',
     'LOGIN': 'auth/login/',
     'LOGOUT': 'auth/logout/',
 }
 
 c = RestApi(options)
 
-ok = c.login(email=email, password=password)
+ok = c.login(username=username, password=password)
 if ok:
 
     # GET some data

--- a/example.py
+++ b/example.py
@@ -34,7 +34,9 @@ if ok:
 
     logger.info('------------------------------')
     logger.info('------------------------------')
-    my_object = c.org('arch-internal').get()
+    # If the URL includes "-", add under parenthesis:
+    # GET: /api/v1/someresource/some-path/
+    my_object = c.someresource('some-path').get()
     pprint(my_object)
     logger.info('------------------------------')
     logger.info('------------------------------')
@@ -44,7 +46,7 @@ if ok:
         'data2': 'val2',
     }
 
-    resp = c.org.post(data=payload)
+    resp = c.someresource.post(data=payload)
     pprint(resp)
 
     logger.info('------------------------------')

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 pytest
-unittest2
 coverage==3.7.1
 coveralls
 mock

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='django-rest-framework-client',
-    version='0.1.2',
+    version='0.2.0',
     description='Python client for a DjangoRestFramework based web site',
     url='https://github.com/dkarchmer/django-rest-framework-client',
     author='David Karchmer',
@@ -13,10 +13,11 @@ setup(name='django-rest-framework-client',
     install_requires=[
         'requests',
     ],
+    python_requires=">=3.7,<4",
     keywords=["django", "djangorestframework", "Rest",],
     classifiers=[
         "Programming Language :: Python",
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules"

--- a/tests/api.py
+++ b/tests/api.py
@@ -47,7 +47,7 @@ class ApiTestCase(unittest.TestCase):
         }
         m.post('https://example.com/api/v1/auth/login/', text=json.dumps(payload))
 
-        ok = self.api.login(email='user1@test.com', password='pass')
+        ok = self.api.login(username='user1@test.com', password='pass')
         self.assertTrue(ok)
         self.assertEqual(self.api.username, 'user1')
         self.assertEqual(self.api.token, 'big-token')
@@ -61,7 +61,7 @@ class ApiTestCase(unittest.TestCase):
         m.post('https://example.com/api/v1/auth/login/', text=json.dumps(payload))
         m.post('https://example.com/api/v1/auth/logout/', status_code=204)
 
-        ok = self.api.login(email='user1@test.com', password='pass')
+        ok = self.api.login(username='user1@test.com', password='pass')
         self.assertTrue(ok)
 
         self.api.logout()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37
+envlist = py38, py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Drop Python 2.7
Allow login with username instead of forcing to use email
Upgrade to Beta v0.2.0