### PR TITLE
Pass on kwargs further to requests call

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 sudo: false
 python:
-- '3.7'
-- '3.8'
 - '3.9'
+- '3.10'
 install:
 - pip install --upgrade tox-travis -r requirements-build.txt -r requirements-test.txt
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### v0.7.0 (2023-05-08)
 
   * Resource class methods respect additional `**kwargs` parameters and pass them on to the underlying `requests` methods
+  * Fix to support `http://` schema in server url
 
 ### v0.6.0 (2022-10-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### v0.7.0 (2023-05-08)
 
-  * Resource class methods respect additional `**kwargs` parameters and pass them on to the underlying `requests` methods
-  * Fix to support `http://` schema in server url
+  * Migrated to Python 3.10, Python 2 is not supported anymore
+  * Resource class methods respect additional `**kwargs` and `extra_headers` parameters and pass them on to the underlying `requests` methods
+  * Fix to support `http://` schema in the server url
 
 ### v0.6.0 (2022-10-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.7.0 (2023-05-08)
+
+  * Resource class methods respect additional `**kwargs` parameters and pass them on to the underlying `requests` methods
+
 ### v0.6.0 (2022-10-30)
 
   * Add USE_DASHES option to automatically replace underscores ("_") with dashes ("-")

--- a/drf_client/connection.py
+++ b/drf_client/connection.py
@@ -48,7 +48,7 @@ DEFAULT_OPTIONS = {
 logger = logging.getLogger(__name__)
 
 
-class RestResource(object):
+class RestResource:
     """
     Resource provides the main functionality behind a Django Rest Framework based API. It handles the
     attribute -> url, kwarg -> query param, and other related behind the scenes
@@ -164,7 +164,7 @@ class RestResource(object):
             url += '?{0}'.format(args)
         return url
 
-    def _get_header(self):
+    def _get_headers(self):
         headers = DEFAULT_HEADERS
         if self._store['use_token']:
             if not "token" in self._store:
@@ -174,47 +174,41 @@ class RestResource(object):
 
         return headers
 
-    def get(self, **kwargs):
+    def get(self, extra_headers: dict = None, **kwargs):
         args = None
         if 'extra' in kwargs:
             args = kwargs['extra']
-        resp = requests.get(self.url(args), headers=self._get_header())
+        headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
+
+        resp = requests.get(self.url(args), headers=headers)
         return self._process_response(resp)
 
-    def post(self, data=None, **kwargs):
-        if data:
-            payload = json.dumps(data)
-        else:
-            payload = None
+    def post(self, data=None, extra_headers: dict = None, **kwargs):
+        payload = json.dumps(data) if data else None
+        headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
-        resp = requests.post(self.url(), data=payload, headers=self._get_header(), **kwargs)
+        resp = requests.post(self.url(), data=payload, headers=headers, **kwargs)
         return self._process_response(resp)
 
-    def patch(self, data=None, **kwargs):
-        if data:
-            payload = json.dumps(data)
-        else:
-            payload = None
+    def patch(self, data=None, extra_headers: dict = None, **kwargs):
+        payload = json.dumps(data) if data else None
+        headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
-        resp = requests.patch(self.url(), data=payload, headers=self._get_header(), **kwargs)
+        resp = requests.patch(self.url(), data=payload, headers=headers, **kwargs)
         return self._process_response(resp)
 
-    def put(self, data=None, **kwargs):
-        if data:
-            payload = json.dumps(data)
-        else:
-            payload = None
+    def put(self, data=None, extra_headers: dict = None, **kwargs):
+        payload = json.dumps(data) if data else None
+        headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
-        resp = requests.put(self.url(), data=payload, headers=self._get_header(), **kwargs)
+        resp = requests.put(self.url(), data=payload, headers=headers, **kwargs)
         return self._process_response(resp)
 
-    def delete(self, data=None, **kwargs):
-        if data:
-            payload = json.dumps(data)
-        else:
-            payload = None
+    def delete(self, data=None, extra_headers: dict = None, **kwargs):
+        payload = json.dumps(data) if data else None
+        headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
-        resp = requests.delete(self.url(), data=payload, headers=self._get_header(), **kwargs)
+        resp = requests.delete(self.url(), data=payload, headers=headers, **kwargs)
         if 200 <= resp.status_code <= 299:
             if resp.status_code == 204:
                 return True
@@ -226,7 +220,8 @@ class RestResource(object):
     def _get_resource(self, **kwargs):
         return self.__class__(**kwargs)
 
-class Api(object):
+
+class Api:
     token = None
     resource_class = RestResource
     use_token = True

--- a/drf_client/connection.py
+++ b/drf_client/connection.py
@@ -187,7 +187,7 @@ class RestResource(object):
         else:
             payload = None
 
-        resp = requests.post(self.url(), data=payload, headers=self._get_header())
+        resp = requests.post(self.url(), data=payload, headers=self._get_header(), **kwargs)
         return self._process_response(resp)
 
     def patch(self, data=None, **kwargs):
@@ -196,7 +196,7 @@ class RestResource(object):
         else:
             payload = None
 
-        resp = requests.patch(self.url(), data=payload, headers=self._get_header())
+        resp = requests.patch(self.url(), data=payload, headers=self._get_header(), **kwargs)
         return self._process_response(resp)
 
     def put(self, data=None, **kwargs):
@@ -205,7 +205,7 @@ class RestResource(object):
         else:
             payload = None
 
-        resp = requests.put(self.url(), data=payload, headers=self._get_header())
+        resp = requests.put(self.url(), data=payload, headers=self._get_header(), **kwargs)
         return self._process_response(resp)
 
     def delete(self, data=None, **kwargs):
@@ -214,7 +214,7 @@ class RestResource(object):
         else:
             payload = None
 
-        resp = requests.delete(self.url(), data=payload, headers=self._get_header())
+        resp = requests.delete(self.url(), data=payload, headers=self._get_header(), **kwargs)
         if 200 <= resp.status_code <= 299:
             if resp.status_code == 204:
                 return True

--- a/drf_client/connection.py
+++ b/drf_client/connection.py
@@ -183,29 +183,29 @@ class RestResource:
         resp = requests.get(self.url(args), headers=headers)
         return self._process_response(resp)
 
-    def post(self, data=None, extra_headers: dict = None, **kwargs):
-        payload = json.dumps(data) if data else None
+    def post(self, data: dict = None, extra_headers: dict = None, **kwargs):
+        payload = json.dumps(data) if data and "files" not in kwargs else data
         headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
         resp = requests.post(self.url(), data=payload, headers=headers, **kwargs)
         return self._process_response(resp)
 
     def patch(self, data=None, extra_headers: dict = None, **kwargs):
-        payload = json.dumps(data) if data else None
+        payload = json.dumps(data) if data and "files" not in kwargs else data
         headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
         resp = requests.patch(self.url(), data=payload, headers=headers, **kwargs)
         return self._process_response(resp)
 
     def put(self, data=None, extra_headers: dict = None, **kwargs):
-        payload = json.dumps(data) if data else None
+        payload = json.dumps(data) if data and "files" not in kwargs else data
         headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
         resp = requests.put(self.url(), data=payload, headers=headers, **kwargs)
         return self._process_response(resp)
 
     def delete(self, data=None, extra_headers: dict = None, **kwargs):
-        payload = json.dumps(data) if data else None
+        payload = json.dumps(data) if data and "files" not in kwargs else data
         headers = self._get_headers() | extra_headers if extra_headers else self._get_headers()
 
         resp = requests.delete(self.url(), data=payload, headers=headers, **kwargs)

--- a/drf_client/helpers/base_main.py
+++ b/drf_client/helpers/base_main.py
@@ -3,6 +3,8 @@ import logging
 import argparse
 import getpass
 
+from urllib.parse import urlparse
+
 from drf_client.connection import Api as RestApi, DEFAULT_HEADERS
 from drf_client.exceptions import HttpClientError
 
@@ -96,7 +98,7 @@ class BaseMain(object):
         """
         Figure out server domain URL based on --server and --customer args
         """
-        if 'https://' not in self.args.server:
+        if not urlparse(self.args.server).scheme:
             return f'https://{self.args.server}'
         return self.args.server
 

--- a/drf_client/helpers/base_main.py
+++ b/drf_client/helpers/base_main.py
@@ -11,7 +11,7 @@ from drf_client.exceptions import HttpClientError
 LOG = logging.getLogger(__name__)
 
 
-class BaseMain(object):
+class BaseMain:
     parser = None
     args = None
     api = None

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 setup(name='django-rest-framework-client',
-    version='0.6.0',
+    version='0.7.0',
     description='Python client for a DjangoRestFramework based web site',
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='django-rest-framework-client',
     install_requires=[
         'requests',
     ],
-    python_requires=">=3.8,<4",
+    python_requires=">=3.10,<4",
     keywords=["django", "djangorestframework", "drf", "rest-client",],
     classifiers=[
         "Programming Language :: Python",

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -38,7 +38,7 @@ class ResourceTestCase(unittest.TestCase):
             'Authorization': 'JWT my-token'
         }
 
-        headers = self.base_resource._get_header()
+        headers = self.base_resource._get_headers()
         self.assertEqual(headers, expected_headers)
 
     @requests_mock.Mocker()


### PR DESCRIPTION
This allows many more usages of the resource methods, without hacking and using internal methods. Good examples - passing `files` parameter, which was not possible before.