### PR TITLE
Add BaseFacade static class to allow access to API from anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v0.9.0 (2023-08-20)
+
+  * Add isort and Black as formatter
+  * Add static BaseFacade class to allow access to API class and BaseMain options
+
 ### v0.8.0 (2023-07-04)
 
   * Remove support for Python 3.8.

--- a/drf_client/helpers/base_facade.py
+++ b/drf_client/helpers/base_facade.py
@@ -1,0 +1,25 @@
+"""Hold static information that can be accessed by any part of the package.
+
+A facade is an object that serves as a front-facing interface masking more complex
+underlying or structural code.
+"""
+from argparse import Namespace
+
+from drf_client.connection import Api as RestApi
+
+
+class BaseFacade:
+    """Stores key static information used across the package."""
+
+    api: RestApi or None = None
+    api_options: dict or None = None
+    cmd_args: Namespace or None = None
+
+    @staticmethod
+    def initialize_api(api_options: dict, cmd_args: Namespace = None):
+        """Initialize API with the given options."""
+        if BaseFacade.api is None:
+            # Only initialize ones
+            BaseFacade.api_options = api_options.copy()
+            BaseFacade.api = RestApi(api_options)
+            BaseFacade.cmd_args = cmd_args

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 # The directory containing this file
 HERE = pathlib.Path(__file__).parent
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="django-rest-framework-client",
-    version="0.8.0",
+    version="0.9.0",
     description="Python client for a DjangoRestFramework based web site",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,15 @@
+"""test Resource class."""
+import argparse
+import unittest
+
+from drf_client.helpers.base_facade import BaseFacade
+
+
+class FacadeTestCase(unittest.TestCase):
+    """Test static facade class."""
+
+    def test_initialize_facade(self):
+        """Test Initializer."""
+        BaseFacade.initialize_api({"DOMAIN": "https://example.com"})
+        assert BaseFacade.api_options["DOMAIN"] == "https://example.com"
+        assert BaseFacade.api is not None

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39, py310
+envlist = py310, py311
 
 [testenv]
 deps =


### PR DESCRIPTION

BaseMain creates the `Api` class as a singleton and now stores it on a static Facade class that can be accessed from anywhere