### PR TITLE
Add support to Bearer Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.10.0 (2023-10-04)
+
+  * Add support to use a permanent Token.
+
 ### v0.9.2 (2023-08-25)
 
   * Fix bug using BaseFacade

--- a/drf_client/helpers/base_main.py
+++ b/drf_client/helpers/base_main.py
@@ -145,12 +145,13 @@ class BaseMain:
         """
         if self.args.token:
             self.api.set_token(self.args.token)
+            LOG.info("Bearer Token has been set.")
             ok = True
         else:
             password = getpass.getpass()
             ok = self.api.login(username=self.args.username, password=password)
             if ok:
-                LOG.info("Welcome {0}".format(self.args.username))
+                LOG.info("Welcome {0}.".format(self.args.username))
         return ok
 
     def before_login(self):

--- a/drf_client/helpers/base_main.py
+++ b/drf_client/helpers/base_main.py
@@ -58,10 +58,10 @@ class BaseMain:
             "-t",
             "--use-token",
             dest="use_token",
-            type=str,
+            type=bool,
             default=False,
             required=False,
-            help="Bearer Token",
+            help="Use token (expects DRF_CLIENT_AUTH_TOKEN to be defined as an env variable)",
         )
         self.parser.add_argument(
             "--server",
@@ -139,9 +139,9 @@ class BaseMain:
         Get password from user and login
         """
         if self.args.use_token:
-            token = os.getenv("AUTH_TOKEN")
+            token = os.getenv("DRF_CLIENT_AUTH_TOKEN")
             if not token:
-                self._critical_exit("AUTH_TOKEN must be defined as environment variable.")
+                self._critical_exit("DRF_CLIENT_AUTH_TOKEN must be defined as environment variable.")
             self.api.set_token(token)
             LOG.info("Bearer Token has been set.")
             ok = True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="django-rest-framework-client",
-    version="0.9.2",
+    version="0.10.0",
     description="Python client for a DjangoRestFramework based web site",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The current script only supports basic authentication forcing the developer to refresh the token occasionally for a long run.

This Pull request introduce the support for a Bearer token.

Example of usage:
```
from drf_client.helpers.base_main import BaseMain

class MyClass(Main):

    options = {
        'DOMAIN': None,
        'API_PREFIX': 'api/v1',
        'TOKEN_TYPE': 'bearer',
        'TOKEN_FORMAT': 'Bearer {token}',
        'USERNAME_KEY': 'username',
        'LOGIN': 'auth/login/',
        'LOGOUT': 'auth/logout/',
        'USE_DASHES': False,
    }

export DRF_CLIENT_AUTH_TOKEN=1fe171f65917db0072abc6880196989dd2a20025
python -m my_script.MyClass --server https://mysite.com --use-token t
```
