### PR TITLE
Add support to coroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.12.0 (2025-04-07)
+  * Add support to coroutines
+
 ### v0.11.2 (2024-07-28)
 
   * Format all files with Ruff

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ if ok:
 
 ```
 
+<<<<<<< Updated upstream
 ### Example using Tokens
 
 ```
@@ -101,6 +102,8 @@ export DRF_CLIENT_AUTH_TOKEN=1fe171f65917db0072abc6880196989dd2a20025
 python -m my_script.MyClass --server https://mysite.com --use-token t
 ```
 
+=======
+>>>>>>> Stashed changes
 ## Django Setup
 
 Client assumes by default that all urls should end with a slash (tested with the default
@@ -158,7 +161,7 @@ The opinionated class will execute the basic main flow:
        self.after_login()
 ```
 
-Any of the above functions can be overwritten by derving from this class.
+Any of the above functions can be overwritten by deriving from this class.
 
 Here is a sample script:
 
@@ -180,6 +183,40 @@ class MyScript(BaseMain):
         resp = self.api.foo.bar.get()
         # You can also access the API from the global Facade
         resp = BaseFacade.api.foo.bar.get()
+
+
+if __name__ == '__main__':
+
+    work = MyScript()
+    work.main()
+```
+
+If you wish to implement coroutines to run multiple tasks in parallel, you can use the `asyncio` library.
+
+```python
+import asyncio
+from drf_client.helper.base_main import BaseMain
+from drf_client.helper.base_facade import BaseFacade
+
+class MyScript(BaseMain):
+
+    def add_extra_args(self):
+        # Add extra positional argument (as example)
+        self.parser.add_argument('foo', metavar='foo', type=str, help='RTFM')
+
+    def before_login(self):
+        logger.info('-----------')
+
+    async def process(self):
+        """Main async test"""
+        # foo_bar and foo_baz are coroutines
+        foo_bar = await self.api.foo.bar.async_get()
+        foo_baz = await self.api.foo.baz.async_get()
+
+
+    def  after_login(self):
+        # Main function to OVERWITE and do real work
+        resp = asyncio.run(self.process())
 
 
 if __name__ == '__main__':

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ if ok:
 
 ```
 
-<<<<<<< Updated upstream
 ### Example using Tokens
 
 ```
@@ -102,8 +101,6 @@ export DRF_CLIENT_AUTH_TOKEN=1fe171f65917db0072abc6880196989dd2a20025
 python -m my_script.MyClass --server https://mysite.com --use-token t
 ```
 
-=======
->>>>>>> Stashed changes
 ## Django Setup
 
 Client assumes by default that all urls should end with a slash (tested with the default

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,27 @@
 groups = ["default", "dev", "ruff"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:533f98bb401ebc9c407ce106dc661cd7476f91d36fcce843dae1ac0583d4fa11"
+content_hash = "sha256:6166a7509dba6f04e059e5e07f33f50d14178825e65debab075a97d63e0f4ad7"
 
 [[metadata.targets]]
 requires_python = "~=3.10"
+
+[[package]]
+name = "anyio"
+version = "4.9.0"
+requires_python = ">=3.9"
+summary = "High level compatibility layer for multiple asynchronous event loop implementations"
+groups = ["default"]
+dependencies = [
+    "exceptiongroup>=1.0.2; python_version < \"3.11\"",
+    "idna>=2.8",
+    "sniffio>=1.1",
+    "typing-extensions>=4.5; python_version < \"3.13\"",
+]
+files = [
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
 
 [[package]]
 name = "backports-tarfile"
@@ -261,7 +278,7 @@ name = "exceptiongroup"
 version = "1.2.2"
 requires_python = ">=3.7"
 summary = "Backport of PEP 654 (exception groups)"
-groups = ["dev"]
+groups = ["default", "dev"]
 marker = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
@@ -277,6 +294,52 @@ groups = ["dev"]
 files = [
     {file = "filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"},
     {file = "filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb"},
+]
+
+[[package]]
+name = "h11"
+version = "0.14.0"
+requires_python = ">=3.7"
+summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+groups = ["default"]
+dependencies = [
+    "typing-extensions; python_version < \"3.8\"",
+]
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+requires_python = ">=3.8"
+summary = "A minimal low-level HTTP client."
+groups = ["default"]
+dependencies = [
+    "certifi",
+    "h11<0.15,>=0.13",
+]
+files = [
+    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
+    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+requires_python = ">=3.8"
+summary = "The next generation HTTP client."
+groups = ["default"]
+dependencies = [
+    "anyio",
+    "certifi",
+    "httpcore==1.*",
+    "idna",
+]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
 ]
 
 [[package]]
@@ -695,6 +758,20 @@ files = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.22.0"
+requires_python = ">=3.8"
+summary = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
+groups = ["default"]
+dependencies = [
+    "httpx>=0.25.0",
+]
+files = [
+    {file = "respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0"},
+    {file = "respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91"},
+]
+
+[[package]]
 name = "rfc3986"
 version = "2.0.0"
 requires_python = ">=3.7"
@@ -776,6 +853,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+requires_python = ">=3.7"
+summary = "Sniff out which async library your code is running under"
+groups = ["default"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
@@ -808,6 +896,18 @@ dependencies = [
 files = [
     {file = "twine-5.1.1-py3-none-any.whl", hash = "sha256:215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997"},
     {file = "twine-5.1.1.tar.gz", hash = "sha256:9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.1"
+requires_python = ">=3.8"
+summary = "Backported and Experimental Type Hints for Python 3.8+"
+groups = ["default"]
+marker = "python_version < \"3.13\""
+files = [
+    {file = "typing_extensions-4.13.1-py3-none-any.whl", hash = "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69"},
+    {file = "typing_extensions-4.13.1.tar.gz", hash = "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ authors = [
 ]
 dependencies = [
     "requests",
+    "httpx>=0.28.1",
+    "respx>=0.22.0",
 ]
 requires-python = ">=3.10,<4"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+httpx

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="django-rest-framework-client",
-    version="0.11.2",
+    version="0.12.2",
     description="Python client for a DjangoRestFramework based web site",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="django-rest-framework-client",
-    version="0.12.2",
+    version="0.12.0",
     description="Python client for a DjangoRestFramework based web site",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,10 @@
+import asyncio
 import json
 import unittest
 
+import httpx
 import requests_mock
+import respx
 
 from drf_client.connection import Api
 from drf_client.exceptions import HttpClientError, HttpServerError
@@ -171,3 +174,109 @@ class ApiTestCase(unittest.TestCase):
 
         with self.assertRaises(HttpServerError):
             self.api.test.post(payload)
+
+    @respx.mock
+    def test_async_get_list(self):
+        payload = {"result": ["a", "b", "c"]}
+        respx.get("https://example.com/api/v1/test/").mock(return_value=httpx.Response(200, json=payload))
+
+        resp = asyncio.run(self.api.test.async_get())
+        self.assertEqual(resp["result"], ["a", "b", "c"])
+
+    @respx.mock
+    def test_async_get_detail(self):
+        payload = {"a": "b", "c": "d"}
+        respx.get("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(200, json=payload))
+        resp = asyncio.run(self.api.test("my-detail").async_get())
+        self.assertEqual(resp, {"a": "b", "c": "d"})
+
+    @respx.mock
+    def test_async_get_detail_with_action(self):
+        payload = {"a": "b", "c": "d"}
+        respx.get("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(200, json=payload))
+        resp = self.api.test("my-detail").action.url()
+        self.assertEqual(resp, "https://example.com/api/v1/test/my-detail/action/")
+        resp = asyncio.run(self.api.test("my-detail").async_get())
+        self.assertEqual(resp, {"a": "b", "c": "d"})
+
+    @respx.mock
+    def test_async_get_with_use_dashes(self):
+        """test that we can replace underscore with dashes."""
+        self.api.options["USE_DASHES"] = True
+        payload = {"a": "b", "c": "d"}
+        respx.get("https://example.com/api/v1/test-one/my-detail/action/").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        resp = asyncio.run(self.api.test_one.my_detail.action.async_get())
+        self.assertEqual(resp, {"a": "b", "c": "d"})
+
+    @respx.mock
+    def test_async_get_detail_with_extra_args(self):
+        payload = {"a": "b", "c": "d"}
+        respx.get("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(200, json=payload))
+        resp = asyncio.run(self.api.test("my-detail").async_get(foo="bar"))
+        self.assertEqual(resp, {"a": "b", "c": "d"})
+
+    @respx.mock
+    def test_async_post(self):
+        payload = {"foo": ["a", "b", "c"]}
+        result = {"id": 1}
+        respx.post("https://example.com/api/v1/test/").mock(return_value=httpx.Response(200, json=result))
+        resp = asyncio.run(self.api.test.async_post(payload))
+        self.assertEqual(resp["id"], 1)
+
+    @respx.mock
+    def test_async_patch(self):
+        payload = {"foo": ["a", "b", "c"]}
+        result = {"id": 1}
+        respx.patch("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(200, json=result))
+        resp = asyncio.run(self.api.test("my-detail").async_patch(payload))
+
+        self.assertEqual(resp["id"], 1)
+
+    @respx.mock
+    def test_async_put(self):
+        payload = {"foo": ["a", "b", "c"]}
+        result = {"id": 1}
+        respx.put("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(200, json=result))
+
+        resp = asyncio.run(self.api.test("my-detail").async_put(payload))
+        self.assertEqual(resp["id"], 1)
+
+    @respx.mock
+    def test_async_delete(self):
+        result = {"id": 1}
+        respx.delete("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(200, json=result))
+
+        deleted = asyncio.run(self.api.test("my-detail").async_delete())
+
+        self.assertTrue(deleted)
+        respx.delete("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(204, json=result))
+
+        deleted = asyncio.run(self.api.test("my-detail").async_delete())
+        self.assertTrue(deleted)
+
+        respx.delete("https://example.com/api/v1/test/my-detail/").mock(return_value=httpx.Response(400, json=result))
+
+        deleted = asyncio.run(self.api.test("my-detail").async_delete())
+        self.assertFalse(deleted)
+
+    @respx.mock
+    def test_async_post_with_error(self):
+        payload = {"foo": ["a", "b", "c"]}
+        result = {"id": 1}
+
+        # 400 Bad Request
+        respx.post("https://example.com/api/v1/test/").mock(return_value=httpx.Response(400, json=result))
+        with self.assertRaises(HttpClientError):
+            asyncio.run(self.api.test.async_post(payload))
+
+        # 404 Not Found
+        respx.post("https://example.com/api/v1/test/").mock(return_value=httpx.Response(404, json=result))
+        with self.assertRaises(HttpClientError):
+            asyncio.run(self.api.test.async_post(payload))
+
+        # 500 Internal Server Error
+        respx.post("https://example.com/api/v1/test/").mock(return_value=httpx.Response(500, json=result))
+        with self.assertRaises(HttpServerError):
+            asyncio.run(self.api.test.async_post(payload))


### PR DESCRIPTION
This PR adds support to run all operations GET/PUT/PATCH/DELETE/POST as coroutines.

To achieve that the following methods are introduced:

- async_post
- async_get
- async_patch
- async_put
- async_delete